### PR TITLE
variable `nIter` previously pointed to no where, but leading to an error...

### DIFF
--- a/ImageSegmentation/vtkImageMRIBrainExtractor.cxx
+++ b/ImageSegmentation/vtkImageMRIBrainExtractor.cxx
@@ -665,7 +665,7 @@ void vtkImageMRIBrainExtractorExecute(
   vtkPoints *originalPoints = vtkPoints::New();
   for (ptIter = brainPoints.begin();
        ptIter != brainPoints.end();
-       ptIter++, nIter++)
+       ptIter++)
     {
     target = *ptIter;
     originalPoints->InsertNextPoint(target.xyz);


### PR DESCRIPTION
variable `nIter` previously pointed to no where, but leading to an error in Visual Studio 2008 at least.
